### PR TITLE
Release v3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [3.0.4] - 2023-02-06
+
 ### Fixed
 - Uses Forward-Headers, so that the application can access scheme information when used with a proxy
 
@@ -37,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Majority of code is now under test.
 
 
-[unreleased]: https://github.com/DanielGilbert/Radia/compare/v3.0.3...HEAD
+[unreleased]: https://github.com/DanielGilbert/Radia/compare/v3.0.4...HEAD
+[3.0.4]: https://github.com/DanielGilbert/Radia/compare/v3.0.3...v3.0.4
 [3.0.3]: https://github.com/DanielGilbert/Radia/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/DanielGilbert/Radia/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/DanielGilbert/Radia/compare/v3.0.0...v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+- Uses Forward-Headers, so that the application can access scheme information when used with a proxy
+
 ## [3.0.3] - 2023-02-06
 
 ### Fixed

--- a/Radia/Radia.csproj
+++ b/Radia/Radia.csproj
@@ -6,9 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <AssemblyVersion>3.0.3</AssemblyVersion>
-    <FileVersion>3.0.3</FileVersion>
-    <Version>3.0.3</Version>
+    <AssemblyVersion>3.0.4</AssemblyVersion>
+    <FileVersion>3.0.4</FileVersion>
+    <Version>3.0.4</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
## [3.0.4] - 2023-02-06

### Fixed
- Uses Forward-Headers, so that the application can access scheme information when used with a proxy