### PR TITLE
Release v3.0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,5 +348,3 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
-docker-compose.override.yml
-/Radia/appsettings.Development.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+## [3.0.9] - 2023-07-17
+
+### Fixed
+- Some new template files didn't get copied to the output folder.
+- When using a different branch than the default branch, the correct branch is now checked out.
+
 ## [3.0.8] - 2023-07-16
 
 ### Added
@@ -79,7 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Majority of code is now under test.
 
 
-[unreleased]: https://github.com/DanielGilbert/Radia/compare/v3.0.8...HEAD
+[unreleased]: https://github.com/DanielGilbert/Radia/compare/v3.0.9...HEAD
+[3.0.8]: https://github.com/DanielGilbert/Radia/compare/v3.0.8...v3.0.9
 [3.0.8]: https://github.com/DanielGilbert/Radia/compare/v3.0.7...v3.0.8
 [3.0.7]: https://github.com/DanielGilbert/Radia/compare/v3.0.6...v3.0.7
 [3.0.6]: https://github.com/DanielGilbert/Radia/compare/v3.0.5...v3.0.6

--- a/Radia/Radia.csproj
+++ b/Radia/Radia.csproj
@@ -22,6 +22,12 @@
     <Content Include="templates\default\css\print.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+	<Content Include="templates\default\css\dark.css">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
+	<Content Include="templates\default\css\common.css">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
     <Content Include="templates\default\favicon.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Radia/Radia.csproj
+++ b/Radia/Radia.csproj
@@ -6,9 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <AssemblyVersion>3.0.8</AssemblyVersion>
-    <FileVersion>3.0.8</FileVersion>
-    <Version>3.0.8</Version>
+    <AssemblyVersion>3.0.9</AssemblyVersion>
+    <FileVersion>3.0.9</FileVersion>
+    <Version>3.0.9</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Radia/Services/FileProviders/Git/GitFileProvider.cs
+++ b/Radia/Services/FileProviders/Git/GitFileProvider.cs
@@ -40,7 +40,8 @@ namespace Radia.Services.FileProviders.Git
             {
                 string path = Repository.Clone(repositoryAddress, localCache, new CloneOptions()
                 {
-                    IsBare = false
+                    IsBare = false,
+                    BranchName = branch
                 });
 
                 repository = new(path);

--- a/Radia/appsettings.Development.json
+++ b/Radia/appsettings.Development.json
@@ -1,0 +1,42 @@
+{
+    "Logging": {
+      "LogLevel": {
+        "Default": "Information",
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "AllowedHosts": "*",
+    "AppConfiguration": {
+      "FileProviderConfigurations": [
+        {
+          "AllowListing": true,
+          "Settings": {
+            "Repository": "https://github.com/DanielGilbert/g5t.de.git",
+            "Branch": "dev"
+          }
+        },
+        {
+          "AllowListing": true,
+          "Settings": {
+            "RootDirectory": "/app/content/"
+          }
+        },
+        {
+          "AllowListing": false,
+          "Settings": {
+            "RootDirectory": "/app/templates/default/views/"
+          }
+        },
+        {
+          "AllowListing": false,
+          "Settings": {
+            "RootDirectory": "/app/templates/default/"
+          }
+        }
+      ],
+      "WebsiteTitle": "Radia",
+      "FooterCopyright": "&copy; &lt;Your name should go here&gt;, 1970 - {{CurrentYear}}",
+      "DefaultPageHeader": "Welcome to Radia"
+    }
+  }
+  

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,8 @@
+version: '3.4'
+
+services:
+  radia:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+    ports:
+      - "80"


### PR DESCRIPTION
## [3.0.9] - 2023-07-17

### Fixed
- Some new template files didn't get copied to the output folder.
- When using a different branch than the default branch, the correct branch is now checked out.